### PR TITLE
Override health check port with $PORT

### DIFF
--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,6 +1,6 @@
 if [[ "$HEALTHCHECK" == "true" ]]; then
 
-    wget -qO- "http://localhost:8080/v1/docker-flow-proxy/ping"
+    wget -qO- "http://localhost:${PORT:-8080}/v1/docker-flow-proxy/ping"
 
     if [[ $? -ne 0 ]]; then
         echo "ERROR: Failed to ping docker-flow-proxy"
@@ -17,7 +17,7 @@ if [[ "$HEALTHCHECK" == "true" ]]; then
     if [[ "$LISTENER_ADDRESS" != "" ]]; then
 
         while true; do
-            wget -qO- "http://localhost:8080/v1/docker-flow-proxy/successfulinitreload"
+            wget -qO- "http://localhost:${PORT:-8080}/v1/docker-flow-proxy/successfulinitreload"
 
             if [[ $? -eq 0 ]]; then
                 exit 0


### PR DESCRIPTION
The proxy server allows you to configure the port that it runs on with the environment variable `PORT`. If you do that, the health check will fail because 8080 is hard-coded and docker-flow-proxy will continually reload itself. This will use the port from `PORT` and fallback to 8080 if it's not found